### PR TITLE
docs(cli): RFC-009 Phase 0 - Add pm.md stub and documentation links

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -11,6 +11,7 @@ Command-line interface documentation for agent-context tools.
 | [agent-mgr.md](agent-mgr.md) | `agent mgr` | Manager commands |
 | [agent-init.md](agent-init.md) | `agent init` | Project initialization |
 | [lint.md](lint.md) | `lint` | Code quality checker |
+| [pm.md](pm.md) | `pm` | Project management (JIRA/GitLab/GitHub) |
 
 ## Quick Reference
 

--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -1,0 +1,84 @@
+# pm
+
+## NAME
+
+pm - Project Management CLI for JIRA/GitLab/GitHub/Confluence
+
+## SYNOPSIS
+
+    pm <PLATFORM> <COMMAND> [OPTIONS]
+    pm config <ACTION>
+    pm create <TITLE> [OPTIONS]
+    pm finish [OPTIONS]
+
+## DESCRIPTION
+
+`pm` is a command-line tool for integrating with project management platforms (JIRA, GitLab, GitHub, Confluence). It provides unified commands for issue tracking, code review, and documentation management.
+
+## QUICK START
+
+```bash
+# 1. Initialize configuration
+pm config init
+
+# 2. Set API tokens
+export JIRA_TOKEN="your-token"
+export GITLAB_TOKEN="your-token"
+
+# 3. Create a feature
+pm create "Add UART driver"
+
+# 4. Finish and create MR
+pm finish
+```
+
+## COMMANDS
+
+### Configuration
+
+| Command | Description |
+|---------|-------------|
+| config init | Create `.project.yaml` |
+| config show | Show current configuration |
+
+### Platform Commands
+
+| Platform | Commands |
+|----------|----------|
+| jira | me, issue (list/view/create) |
+| confluence | me, space, page, search |
+| gitlab | me, mr, issue |
+| github | me, pr, issue |
+
+### Workflow Commands
+
+| Command | Description |
+|---------|-------------|
+| create | Create issue + branch |
+| finish | Push + create MR + update status |
+
+## EXAMPLES
+
+```bash
+# JIRA
+pm jira issue list
+pm jira issue view PROJ-123
+pm jira issue create "New feature"
+
+# GitLab
+pm gitlab mr list
+pm gitlab mr create --source feat/test --title "Test MR"
+
+# GitHub
+pm github pr list
+pm github pr create --head feat/test --title "Test PR"
+
+# Confluence
+pm confluence page list
+pm confluence page create --space SFP --title "New Page"
+```
+
+## SEE ALSO
+
+- **Implementation details**: [tools/pm/README.md](../../tools/pm/README.md)
+- **Related CLI**: [agent.md](agent.md), [lint.md](lint.md)

--- a/tools/pm/README.md
+++ b/tools/pm/README.md
@@ -1,5 +1,7 @@
 # Project Management CLI
 
+> **User manual**: [docs/cli/pm.md](../../docs/cli/pm.md)
+
 Jira/Confluence/GitLab integration CLI for development workflow automation.
 
 ## Requirements


### PR DESCRIPTION
## Summary

RFC-009 (CLI Documentation Policy) Phase 0 구현:

- `docs/cli/pm.md` 생성 (Stub) - pm CLI 사용자 매뉴얼 진입점
- `docs/cli/README.md` Tools 표에 pm 추가
- `tools/pm/README.md` 상단에 User manual 링크 추가

## Background

현재 CLI 문서가 `docs/cli/`와 `tools/*/README.md`에 혼재되어 있어 사용자가 탐색에 어려움을 겪고 있었습니다. RFC-009는 사용자용 CLI 매뉴얼의 정본 위치를 `docs/cli/`로 통일하는 정책을 제안합니다.

## Changes

| File | Change |
|------|--------|
| `docs/cli/pm.md` | NEW - User manual stub for pm CLI |
| `docs/cli/README.md` | ADD pm entry to tools table |
| `tools/pm/README.md` | ADD user manual link at top |

## Test Plan

- [v] `docs/cli/README.md`에서 pm 링크 클릭 시 `pm.md`로 이동 확인
- [v] `tools/pm/README.md`에서 User manual 링크 확인
- [v] `docs/cli/pm.md`에서 Implementation details 링크 확인

## Related

- RFC: `docs/rfcs/009-cli-documentation-policy.md`